### PR TITLE
막대그래프 음수 점수 문제 해결

### DIFF
--- a/games/views.py
+++ b/games/views.py
@@ -163,16 +163,24 @@ def ranking_list(request):
     User = get_user_model()
     users = User.objects.all().order_by('-points')
 
-    # 1등 점수 (그래프 비율 계산용)
-    max_point = users[0].points if users.exists() else 0
+    if not users.exists():
+        return render(request, 'games/ranking.html', {'ranking_data': []})
+
+    max_point = users.first().points
+    min_point = users.last().points
+
+    # 모든 점수가 같은 경우 (0으로 나누기 방지)
+    range_point = max_point - min_point
 
     ranking_data = []
     for idx, user in enumerate(users, start=1):
-        # 0으로 나누기 방지
-        percent = (user.points / max_point * 100) if max_point > 0 else 0
+        if range_point > 0:
+            percent = (user.points - min_point) / range_point * 100
+        else:
+            percent = 100  # 전부 같은 점수면 동일 높이
 
         ranking_data.append({
-            'rank': idx,         
+            'rank': idx,
             'user': user,
             'percent': percent,
         })
@@ -182,6 +190,7 @@ def ranking_list(request):
         'games/ranking.html',
         {'ranking_data': ranking_data}
     )
+
 
 # [게임 상세 페이지] : 결과 화면
 def game_detail_view(request, pk):


### PR DESCRIPTION
랭킹에서 특정 사용자의 총점수가 음수이면 백엔드에서 계산할 때 양수로 계산되어 막대그래프가 오히려 높아지는 현상이 있었음. 해당 부분을 점수 제일 높은 점수, 제일 낮은 점수를 기준으로 상대적으로 막대그래프를 나타내도록 수정함.